### PR TITLE
Modified snow build-up and melting behaviour

### DIFF
--- a/abms.lua
+++ b/abms.lua
@@ -158,6 +158,7 @@ minetest.register_abm({
 -- Snow Melting
 minetest.register_abm({
 	nodenames = {"mymonths:snow_cover_1", "mymonths:snow_cover_2", "mymonths:snow_cover_3", "mymonths:snow_cover_4", "mymonths:snow_cover_5", "default:snowblock", "default:snow"},
+	neighbors = {"air"},
 	interval = 10,
 	chance = 1,
 
@@ -177,7 +178,14 @@ minetest.register_abm({
 
 		if math.random(1, 100) == 1 then
 
-			if node.name == "mymonths:snow_cover_2" or "default:snow" then
+			-- check if there is any blocks above it
+			while minetest.get_node_or_nil({x=pos.x, y=pos.y + 1, z=pos.z}) and
+				 minetest.get_node_or_nil({x=pos.x, y=pos.y + 1, z=pos.z}).name ~= "air" do
+				pos.y = pos.y + 1
+				node = minetest.get_node_or_nil(pos)
+			end
+
+			if node.name == "mymonths:snow_cover_2" or node.name == "default:snow" then
 
 				minetest.set_node(pos, {name = "mymonths:snow_cover_1"})
 
@@ -193,7 +201,7 @@ minetest.register_abm({
 
 				minetest.set_node(pos, {name = "mymonths:snow_cover_4"})
 
-			elseif node.name == "defalt:snowblock" then
+			elseif node.name == "default:snowblock" then
 
 				minetest.set_node(pos, {name = "mymonths:snow_cover_5"})
 

--- a/abms.lua
+++ b/abms.lua
@@ -135,6 +135,8 @@ minetest.register_abm({
 					
 					local depth = 2
 
+					local snow_biome = minetest.find_node_near(pos, 5, {"default:ice"})
+
 					-- checks the number of snow blocks below to determine if snow is too deep
 					local count = 0
 					for i = 1, depth do
@@ -147,7 +149,7 @@ minetest.register_abm({
 						end
 					end
 
-					if level_snow(pos, node, 0) and count ~= depth then
+					if level_snow(pos, node, 0) and (count ~= depth or snow_biome) then
 						minetest.set_node(pos, {name = "default:snowblock"})
 					end
 				end
@@ -167,6 +169,12 @@ minetest.register_abm({
 		if mymonths.month_counter == 12
 		or mymonths.month_counter == 1
 		or mymonths.month_counter == 2 then
+			return
+		end
+
+		-- check if in a snow biome
+		local snow_biome = minetest.find_node_near(pos, 5, {"default:ice"})
+		if snow_biome ~= nil then
 			return
 		end
 

--- a/abms.lua
+++ b/abms.lua
@@ -3,7 +3,7 @@
 if mymonths.snow_on_ground == true then
 
 minetest.register_abm({
-	nodenames = {"default:leaves", "default:dirt", "default:dirt_with_grass"},
+	nodenames = {"group:leaves", "group:soil"},
 	neighbors = {"air"},
 	interval = 8,
 	chance = 20,
@@ -55,8 +55,8 @@ minetest.register_abm({
 
 -- Changes snow to larger snow
 minetest.register_abm({
-	nodenames = {"mymonths:snow_cover_1", "mymonths:snow_cover_2", "mymonths:snow_cover_3", "mymonths:snow_cover_4"},
-	neighbors = {"default:dirt", "default:dirt_with_grass"},
+	nodenames = {"mymonths:snow_cover_1", "mymonths:snow_cover_2", "mymonths:snow_cover_3", "mymonths:snow_cover_4", "default:snow"},
+	neighbors = {"group:soil", "default:snowblock"},
 	interval = 20,
 	chance = 40,
 
@@ -74,7 +74,7 @@ minetest.register_abm({
 
 					minetest.set_node(pos, {name = "mymonths:snow_cover_2"})
 
-				elseif node.name == "mymonths:snow_cover_2" then
+				elseif node.name == "mymonths:snow_cover_2" or node.name == "default:snow" then
 
 					minetest.set_node(pos, {name = "mymonths:snow_cover_3"})
 
@@ -85,6 +85,10 @@ minetest.register_abm({
 				elseif node.name == "mymonths:snow_cover_4" then
 
 					minetest.set_node(pos, {name = "mymonths:snow_cover_5"})
+
+				elseif node.name == "mymonths:snow_cover_5" then
+
+					minetest.set_node(pos, {name = "default:snowblock"})
 				end
 			end
 	end
@@ -92,7 +96,7 @@ minetest.register_abm({
 
 -- Snow Melting
 minetest.register_abm({
-	nodenames = {"mymonths:snow_cover_1", "mymonths:snow_cover_2", "mymonths:snow_cover_3", "mymonths:snow_cover_4", "mymonths:snow_cover_5"},
+	nodenames = {"mymonths:snow_cover_1", "mymonths:snow_cover_2", "mymonths:snow_cover_3", "mymonths:snow_cover_4", "mymonths:snow_cover_5", "default:snowblock"},
 	interval = 10,
 	chance = 1,
 
@@ -128,6 +132,10 @@ minetest.register_abm({
 
 				minetest.set_node(pos, {name = "mymonths:snow_cover_4"})
 
+			elseif node.name == "defalt:snowblock" then
+
+				minetest.set_node(pos, {name = "mymonths:snow_cover_5"})
+
 			elseif node.name == "mymonths:snow_cover_1" then
 
 				local nu = minetest.get_node({x = pos.x, y = pos.y - 1, z = pos.z})
@@ -150,7 +158,7 @@ if mymonths.use_puddles == true then
 
 -- Makes Puddles when raining
 minetest.register_abm({
-	nodenames = {"default:dirt", "default:dirt_with_grass"},
+	nodenames = {"group:soil"},
 	neighbors = {"default:air"},
 	interval = 10,
 	chance = 50,


### PR DESCRIPTION
Changed code to allow snow to turn into snow blocks and grow deeper. currently set to stop growing if there are two complete snow blocks below it. (possible future settings option)

Added snow "drifting". Snow_cover_5 nodes will check adjacent nodes and see if they are within a given height difference before turning the snow_cover_5 node into a snow block. Current implementation is recursive to allow the snow to "drift" further than one node from the original. The function call is set to escape after 5 recursive calls with no valid candidate to place the snow.

Modified the melting behavior to prevent snow nodes from melting while there is another node above them. Also added check to see if the node in within a snow/ice biome, is the node within 5 blocks of an ice block.

modified the nodename lists in the register_abm function call to use node groups instead of individual node names.