### PR TITLE
Added dynamic melting behavior and prevented snow or particles from forming under transparent blocks

### DIFF
--- a/abms.lua
+++ b/abms.lua
@@ -98,10 +98,10 @@ minetest.register_abm({
 		if (mymonths.weather == "snow" or mymonths.weather == "snowstorm")
 		and biome_jungle == nil then
 
-			if minetest.get_node_light(pos, 0.5) == 15
-			and na.name == "air" then
+			if not is_inside(pos) and na.name == "air" then
 
 				minetest.set_node(pos, {name = "mymonths:snow_cover_1"})
+
 			end
 		end
 	end
@@ -121,15 +121,9 @@ minetest.register_abm({
 		if mymonths.weather == "snow" or mymonths.weather == "snowstorm"
 		and biome_jungle == nil then
 
-			if minetest.get_node_light({
-				x = pos.x,
-				y = pos.y + 1,
-				z = pos.z}, 0.5) == 15 then
-
-					if not is_inside(ppos) then
-						minetest.set_node(pos, {name="mymonths:snow_cover_1"})
-					end
-			end
+				if not is_inside(pos) then
+					minetest.set_node(pos, {name="mymonths:snow_cover_1"})
+				end
 		end
 	end
 })

--- a/abms.lua
+++ b/abms.lua
@@ -27,7 +27,7 @@ local function level_snow(pos, node, depth)
 			if snow_level[node.name][2] - snow_level[temp_node.name][2] > 2 then
 				-- shift the node down till it can be filled
 				if temp_node.name == "air" then
-					while minetest.get_node_or_nil({x=sides[i].x, y=sides[i].y - 1, z=sides[i].z}) ~= nil and 
+					while minetest.get_node_or_nil({x=sides[i].x, y=sides[i].y - 1, z=sides[i].z}) ~= nil and
 							snow_level[minetest.get_node_or_nil({x=sides[i].x, y=sides[i].y - 1, z=sides[i].z}).name] ~= nil do
 						sides[i].y = sides[i].y - 1
 					end
@@ -41,6 +41,23 @@ local function level_snow(pos, node, depth)
 		end
 	end
 	return true
+end
+
+local function is_inside(pos)
+
+	if minetest.get_node_light({x=pos.x,y=pos.y+1,z=pos.z}, 0.5) ~= 15 then
+		return true
+	end
+
+	local temp_node = minetest.get_node_or_nil({x=pos.x,y=pos.y+1,z=pos.z})
+
+	for i = 2,50 do
+		if temp_node ~= nil and temp_node.name ~= "air" then
+			return true
+		end
+		temp_node = minetest.get_node_or_nil({x=pos.x,y=pos.y+i,z=pos.z})
+	end
+	return false
 end
 
 local function get_melt_prob(pos)
@@ -109,7 +126,9 @@ minetest.register_abm({
 				y = pos.y + 1,
 				z = pos.z}, 0.5) == 15 then
 
-					minetest.set_node(pos, {name="mymonths:snow_cover_1"})
+					if not is_inside(ppos) then
+						minetest.set_node(pos, {name="mymonths:snow_cover_1"})
+					end
 			end
 		end
 	end
@@ -149,7 +168,7 @@ minetest.register_abm({
 					minetest.set_node(pos, {name = "mymonths:snow_cover_5"})
 
 				elseif node.name == "mymonths:snow_cover_5" then
-					
+
 					local depth = 2
 
 					local snow_biome = minetest.find_node_near(pos, 5, {"default:ice"})

--- a/weather.lua
+++ b/weather.lua
@@ -1,3 +1,20 @@
+local function is_inside(pos)
+
+	if minetest.get_node_light({x=pos.x,y=pos.y+1,z=pos.z}, 0.5) ~= 15 then
+		return true
+	end
+	
+	local temp_node = minetest.get_node_or_nil({x=pos.x,y=pos.y+1,z=pos.z})
+
+	for i = 2,50 do
+		if temp_node ~= nil and temp_node.name ~= "air" then
+			return true
+		end
+		temp_node = minetest.get_node_or_nil({x=pos.x,y=pos.y+i,z=pos.z})
+	end
+	return false
+end
+
 
 --Sets the weather types for each month
 local t = 0
@@ -208,9 +225,10 @@ minetest.register_globalstep(function(dtime)
 		local nodein = minetest.get_node(ppos)
 		local nodeu = minetest.get_node({x = ppos.x, y = ppos.y - 1, z = ppos.z})
 		
-		local biome_jungle = minetest.find_node_near(ppos, 5, "default:jungletree", "default:junglegrass")
-		local biome_desert = minetest.find_node_near(ppos, 5, "default:desert_sand", "default:desert_stone")
-		local biome_snow = minetest.find_node_near(ppos, 5, "default:snow", "default:snowblock", "default:dirt_with_snow", "default:ice")
+		local biome_jungle = minetest.find_node_near(ppos, 8, "default:jungletree", "default:junglegrass")
+		local biome_desert = minetest.find_node_near(ppos, 8, "default:desert_sand", "default:desert_stone")
+		local biome_snow = minetest.find_node_near(ppos, 8, "default:snow", "default:snowblock", "default:dirt_with_snow",
+					 "default:ice", "default:pine_tree", "mymonths:snow_cover_5")
 		
 		local minp = addvectors(ppos, {x = -10, y = 7, z = -10})
 		local maxp = addvectors(ppos, {x = 10, y = 7, z = 10})
@@ -249,17 +267,13 @@ minetest.register_globalstep(function(dtime)
 			player:set_physics_override(1, 1, 1, true, false)
 		end
 
-		-- check light to make sure player is outside
-		if minetest.get_node_light({
-			x = ppos.x,
-			y = ppos.y + 1,
-			z = ppos.z}, 0.5) ~= 15 then
-
+		-- checks if there is any weather
+		if mymonths.weather2 == "none" then
 			return
 		end
 
-		-- checks if there is any weather
-		if mymonths.weather2 == "none" then
+		-- check light to make sure player is outside
+		if is_inside(ppos) then
 			return
 		end
 
@@ -329,11 +343,7 @@ minetest.register_globalstep(function(dtime)
 				playername = name
 			})
 
-			if minetest.get_node_light({
-				x = ppos.x,
-				y = ppos.y + 1,
-				z = ppos.z}, 0.5) == 15
-			and mymonths.damage == true then
+			if not is_inside(ppos) and mymonths.damage == true then
 
 				if hp_t >= 15 then
 					player:set_hp(hp - 1)
@@ -451,12 +461,7 @@ minetest.register_globalstep(function(dtime)
 				playername = name
 			})
 
-			if minetest.get_node_light({
-				x = ppos.x,
-				y = ppos.y + 1,
-				z =ppos.z}, 0.5) == 15
-			and mymonths.damage == true then
-
+			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then
 					player:set_hp(hp - 1)
 					hp_t = 0
@@ -484,12 +489,7 @@ minetest.register_globalstep(function(dtime)
 				playername = name
 			})
 
-			if minetest.get_node_light({
-				x = ppos.x,
-				y = ppos.y + 1,
-				z = ppos.z}, 0.5) == 15
-			and mymonths.damage == true then
-
+			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then
 					player:set_hp(hp - 1)
 					hp_t = 0
@@ -517,12 +517,7 @@ minetest.register_globalstep(function(dtime)
 				playername = name
 			})
 
-			if minetest.get_node_light({
-				x = ppos.x,
-				y = ppos.y + 1,
-				z = ppos.z}, 0.5) == 15
-			and mymonths.damage == true then
-
+			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then
 					player:set_hp(hp - 1)
 					hp_t = 0


### PR DESCRIPTION
Implemented dynamic melting behavior, meaning snow nodes are less likely to melt for every snow node, ice block, and pine tree near it. Basically snow in a pine forest will melt slower than snow in an open field. Should not melt snow in snow planes. Possible future changes may include adding a bias for the month, snow in November will melt a lot slower than in May.

Updated particle spawning and snow depositing behavior to prevent either from forming below a transparent block. I had the issue that rain particles were showing while inside a glass green house and later in the year having snow break my plants. Currently it checks the 50 nodes above to confirm if the node-player is inside or not, I have not checked how much this changes performance but I have not been able to notice any major changes.