### PR TITLE
Implement attached particle spawners for weather effects

### DIFF
--- a/weather.lua
+++ b/weather.lua
@@ -207,6 +207,229 @@ end
 
 hp_t = 0
 
+--structure:
+--[[
+active_particlespawners = {
+	[player_name] = {
+		pSpawnerId1,
+		pSpawnerId2,
+		...
+		pSpawnerIdn
+	}
+}
+]]--
+mymonths.active_particlespawners={}
+--used to determine if to remove old and add new particle spawners
+mymonths.last_weather2="none"
+function mymonths.update_weather_particles(player)
+	
+	mymonths.remove_weather_particles(player)
+	
+	local name=player:get_player_name()
+	
+	local minp = {x = -20, y = 7, z = -20}
+	local maxp = {x = 20, y = 7, z = 20}
+	local minps = {x =-20, y = 0, z = -20}
+	local maxps = {x = 20, y = 3, z = 20}
+	local minp_deep = {x = -20, y = 3.2, z = -20}
+	local maxp_deep = {x = 20, y = 2.6, z = 20}
+	local vel_rain = {x = 0, y = -4, z = 0}
+	local acc_rain = {x = 0, y = -9.81, z = 0}
+	local vel_snow = {x = 0, y = -0.4, z = 0}
+	local acc_snow = {x = 0, y = -0.5, z = 0}
+	local vel_sand = {x = 1, y = -0.1, z = 0}
+	local acc_sand = {x = 2, y = 0, z = 0}
+	
+	local l={}
+	
+	if mymonths.weather2 == "storm" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 4000,
+			time = 0,
+			minpos = minp,
+			maxpos = maxp,
+			minvel = vel_rain,
+			maxvel = vel_rain,
+			minacc = acc_rain,
+			maxacc = acc_rain,
+			minexptime = 0.8,
+			maxexptime = 0.8,
+			minsize = 25,
+			maxsize = 40,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_rain_dark.png",
+			playername = name,
+			attached = player
+		})
+
+	elseif mymonths.weather2 == "rain" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 1500,
+			time = 0,
+			minpos = minp,
+			maxpos = maxp,
+			minvel = vel_rain,
+			maxvel = vel_rain,
+			minacc = acc_rain,
+			maxacc = acc_rain,
+			minexptime = 0.6,
+			maxexptime = 0.8,
+			minsize = 25,
+			maxsize = 25,
+			collisiondetection = false,
+			vertical = true, 
+			texture = "weather_rain.png",
+			playername = name,
+			attached = player
+		})
+
+	elseif mymonths.weather2 == "snow" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 400,
+			time = 0,
+			minpos = minp,
+			maxpos = maxp,
+			minvel = vel_snow,
+			maxvel = vel_snow,
+			minacc = acc_snow,
+			maxacc = acc_snow,
+			minexptime = 4,
+			maxexptime = 8,
+			minsize = 15,
+			maxsize = 25,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_snow.png",
+			playername = name,
+			attached = player
+		})
+
+		l[2] = minetest.add_particlespawner({
+			amount = 400,
+			time = 0,
+			minpos = minp_deep,
+			maxpos = maxp_deep,
+			minvel = vel_snow,
+			maxvel = vel_snow,
+			minacc = acc_snow,
+			maxacc = acc_snow,
+			minexptime = 4,
+			maxexptime = 6,
+			minesize = 15,
+			maxsize = 25,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_snow.png",
+			playername = name,
+			attached = player
+		})
+
+	elseif mymonths.weather2 == "snowstorm" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 2500,
+			time = 0,
+			minpos = minp,
+			maxpos = maxp,
+			minvel = vel_snow,
+			maxvel = vel_snow,
+			minacc = acc_snow,
+			maxacc = acc_snow,
+			minexptime = 4,
+			maxexptime = 6,
+			minesize = 15,
+			maxsize = 35,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_snow.png",
+			playername = name,
+			attached = player
+		})
+
+		l[2] = minetest.add_particlespawner({
+			amount = 2500,
+			time = 0,
+			minpos = minp_deep,
+			maxpos = maxp_deep,
+			minvel = vel_snow,
+			maxvel = vel_snow,
+			minacc = acc_snow,
+			maxacc = acc_snow,
+			minexptime = 4,
+			maxexptime = 6,
+			minesize = 15,
+			maxsize = 25,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_snow.png",
+			playername = name,
+			attached = player
+		})
+
+	elseif mymonths.weather2 == "sandstorm" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 3500,
+			time = 0,
+			minpos = minps,
+			maxpos = maxps,
+			minvel = vel_sand,
+			maxvel = vel_sand,
+			minacc = acc_sand,
+			maxacc = acc_sand,
+			minexptime = 4,
+			maxexptime = 4,
+			minesize = 5,
+			maxsize = 10,
+			collisiondetection = false,
+			vertical = true,
+			texture = "weather_sand.png",
+			playername = name,
+			attached = player
+		})
+
+	elseif mymonths.weather2 == "hail" then
+
+		l[1] = minetest.add_particlespawner({
+			amount = 3500,
+			time = 0,
+			minpos = minp,
+			maxpos = maxp,
+			minvel = vel_rain,
+			maxvel = vel_rain,
+			minacc = acc_rain,
+			maxacc = acc_rain,
+			minexptime = 1,
+			maxexptime = 1,
+			minesize = 5,
+			maxsize = 10,
+			collisiondetection = true,
+			vertical = true,
+			texture = "weather_hail.png",
+			playername = name,
+			attached = player
+		})
+	end
+	mymonths.active_particlespawners[name]=l
+end
+function mymonths.remove_weather_particles(player)
+	local pname=player:get_player_name()
+	if not mymonths.active_particlespawners[pname] then return end
+	for _,pid in ipairs(mymonths.active_particlespawners[pname]) do
+		minetest.delete_particlespawner(pid)
+	end
+	mymonths.active_particlespawners[pname]={}
+end
+minetest.register_on_joinplayer(function()
+	--enforce weather particle re-initialization on next step
+	mymonths.last_weather2=""
+end)
+
+
 minetest.register_globalstep(function(dtime)
 
 	hp_t = hp_t + dtime
@@ -229,19 +452,6 @@ minetest.register_globalstep(function(dtime)
 		local biome_desert = minetest.find_node_near(ppos, 8, "default:desert_sand", "default:desert_stone")
 		local biome_snow = minetest.find_node_near(ppos, 8, "default:snow", "default:snowblock", "default:dirt_with_snow",
 					 "default:ice", "default:pine_tree", "mymonths:snow_cover_5")
-		
-		local minp = addvectors(ppos, {x = -10, y = 7, z = -10})
-		local maxp = addvectors(ppos, {x = 10, y = 7, z = 10})
-		local minps = addvectors(ppos, {x =-15, y = 0, z = -10})
-		local maxps = addvectors(ppos, {x = 5, y = 3, z = 10})
-		local minp_deep = addvectors(ppos, {x = -10, y = 3.2, z = -10})
-		local maxp_deep = addvectors(ppos, {x = 10, y = 2.6, z = 10})
-		local vel_rain = {x = 0, y = -4, z = 0}
-		local acc_rain = {x = 0, y = -9.81, z = 0}
-		local vel_snow = {x = 0, y = -0.4, z = 0}
-		local acc_snow = {x = 0, y = -0.5, z = 0}
-		local vel_sand = {x = 1, y = -0.1, z = 0}
-		local acc_sand = {x = 2, y = 0, z = 0}
 
 		-- slows players walk in snow
 		if nodein.name == "mymonths:snow_cover_1" then
@@ -321,27 +531,13 @@ minetest.register_globalstep(function(dtime)
 		else
 			mymonths.weather2 = mymonths.weather
 		end
+		
+		if mymonths.weather2 ~= mymonths.last_weather2 then
+			mymonths.update_weather_particles(player)
+			mymonths.last_weather2 = mymonths.weather2
+		end
 	
 		if mymonths.weather2 == "storm" then
-
-			minetest.add_particlespawner({
-				amount = 40,
-				time = 0.5,
-				minpos = minp,
-				maxpos = maxp,
-				minvel = vel_rain,
-				maxvel = vel_rain,
-				minacc = acc_rain,
-				maxacc = acc_rain,
-				minexptime = 0.8,
-				maxexptime = 0.8,
-				minsize = 25,
-				maxsize = 40,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_rain_dark.png",
-				playername = name
-			})
 
 			if not is_inside(ppos) and mymonths.damage == true then
 
@@ -360,106 +556,7 @@ minetest.register_globalstep(function(dtime)
 				})
 			end
 
-		elseif mymonths.weather2 == "rain" then
-
-			minetest.add_particlespawner({
-				amount = 15,
-				time = 0.5,
-				minpos = minp,
-				maxpos = maxp,
-				minvel = vel_rain,
-				maxvel = vel_rain,
-				minacc = acc_rain,
-				maxacc = acc_rain,
-				minexptime = 0.6,
-				maxexptime = 0.8,
-				minsize = 25,
-				maxsize = 25,
-				collisiondetection = false,
-				vertical = true, 
-				texture = "weather_rain.png",
-				playername = name
-			})
-
-		elseif mymonths.weather2 == "snow" then
-
-			minetest.add_particlespawner({
-				amount = 4,
-				time = 0.5,
-				minpos = minp,
-				maxpos = maxp,
-				minvel = vel_snow,
-				maxvel = vel_snow,
-				minacc = acc_snow,
-				maxacc = acc_snow,
-				minexptime = 4,
-				maxexptime = 8,
-				minsize = 15,
-				maxsize = 25,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_snow.png",
-				playername = name
-			})
-
-			minetest.add_particlespawner({
-				amount = 4,
-				time = 0.5,
-				minpos = minp_deep,
-				maxpos = maxp_deep,
-				minvel = vel_snow,
-				maxvel = vel_snow,
-				minacc = acc_snow,
-				maxacc = acc_snow,
-				minexptime = 4,
-				maxexptime = 6,
-				minesize = 15,
-				maxsize = 25,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_snow.png",
-				playername = name
-			})
-
 		elseif mymonths.weather2 == "snowstorm" then
-
-			minetest.add_particlespawner({
-				amount = 25,
-				time = 0.5,
-				minpos = minp,
-				maxpos = maxp,
-				minvel = vel_snow,
-				maxvel = vel_snow,
-				minacc = acc_snow,
-				maxacc = acc_snow,
-				minexptime = 4,
-				maxexptime = 6,
-				minesize = 15,
-				maxsize = 35,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_snow.png",
-				playername = name
-			})
-
-			minetest.add_particlespawner({
-				amount = 25,
-				time = 0.5,
-				minpos = minp_deep,
-				maxpos = maxp_deep,
-				minvel = vel_snow,
-				maxvel = vel_snow,
-				minacc = acc_snow,
-				maxacc = acc_snow,
-				minexptime = 4,
-				maxexptime = 6,
-				minesize = 15,
-				maxsize = 25,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_snow.png",
-				playername = name
-			})
 
 			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then
@@ -470,25 +567,6 @@ minetest.register_globalstep(function(dtime)
 
 		elseif mymonths.weather2 == "sandstorm" then
 
-			minetest.add_particlespawner({
-				amount = 35,
-				time = 0.5,
-				minpos = minps,
-				maxpos = maxps,
-				minvel = vel_sand,
-				maxvel = vel_sand,
-				minacc = acc_sand,
-				maxacc = acc_sand,
-				minexptime = 4,
-				maxexptime = 4,
-				minesize = 5,
-				maxsize = 10,
-				collisiondetection = false,
-				vertical = true,
-				texture = "weather_sand.png",
-				playername = name
-			})
-
 			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then
 					player:set_hp(hp - 1)
@@ -497,25 +575,6 @@ minetest.register_globalstep(function(dtime)
 			end
 
 		elseif mymonths.weather2 == "hail" then
-
-			minetest.add_particlespawner({
-				amount = 35,
-				time = 0.5,
-				minpos = minp,
-				maxpos = maxp,
-				minvel = vel_rain,
-				maxvel = vel_rain,
-				minacc = acc_rain,
-				maxacc = acc_rain,
-				minexptime = 1,
-				maxexptime = 1,
-				minesize = 5,
-				maxsize = 10,
-				collisiondetection = true,
-				vertical = true,
-				texture = "weather_hail.png",
-				playername = name
-			})
 
 			if not is_inside(ppos) and mymonths.damage == true then
 				if hp_t >= 15 then


### PR DESCRIPTION
This PR rewrites the weather system to use attached particle spawners. This massively reduces network/server load and lagginess.
The particle spawner 'amount' values still need a bit tweaking.
Please merge this a while after Minetest 0.4.15 has been released, since attached particle spawners are only found in latest development versions.
