### PR TITLE
Custom timescale

### DIFF
--- a/months.lua
+++ b/months.lua
@@ -1,6 +1,8 @@
 local timechange = 0
 local gm = 0
 local gn = 0
+-- TODO should be read from configuration file
+local timescale = 72
 
 -- Set holidays
 local hol = {
@@ -63,8 +65,8 @@ minetest.register_globalstep(function(dtime)
 	local mc = tonumber(mymonths.month_counter)
 	local x = ((mc-1)*14)+dc
 	local ratio = ((math.cos((x / 168) * 2 * math.pi) * 0.8) / 2.0) + 0.5
-	local nightratio = math.floor(72*(ratio+0.5))
-	local dayratio =  math.floor(72/(ratio+0.5))
+	local nightratio = math.floor(timescale * (ratio + 0.5))
+	local dayratio =  math.floor(timescale / (ratio + 0.5))
 
 	--Checks for morning
 	local time_in_seconds = minetest.get_timeofday() * 24000

--- a/months.lua
+++ b/months.lua
@@ -1,8 +1,11 @@
 local timechange = 0
 local gm = 0
 local gn = 0
--- TODO should be read from configuration file
 local timescale = 72
+-- If exists read timescale from config and store locally to prevent outside modification
+if mymonths.timescale ~= nil then
+	timescale = mymonths.timescale
+end	
 
 -- Set holidays
 local hol = {

--- a/settings.txt.example
+++ b/settings.txt.example
@@ -21,3 +21,7 @@ mymonths.snow_on_ground = true
 --Puddles appear when raining
 
 mymonths.use_puddles = true
+
+--Set custom speed of time
+
+mymonths.timescale = 72


### PR DESCRIPTION
Allow setting a custom timescale instead of the default value of 72 that was hardcoded. 
Read value from configuration file and if set overwrite the local parameter to prevent changes when the game is running. 

Additionally I could create an ingame command to set the parameter, if desired.