### PR TITLE
Replace Augest with August

### DIFF
--- a/command.lua
+++ b/command.lua
@@ -110,7 +110,7 @@ minetest.register_chatcommand("setmonth", {
 		or param == "august"
 		or param == "aug" then
 
-			mymonths.month = "Augest"
+			mymonths.month = "August"
 			mymonths.month_counter = 8
 			minetest.chat_send_player(name, "Month has been changed to August")
 
@@ -259,7 +259,7 @@ minetest.register_chatcommand("holidays", {
 		minetest.chat_send_player(name, "Friendship Day - March 12")
 		minetest.chat_send_player(name, "Miners Day - April 10")
 		minetest.chat_send_player(name, "Minetest Day - June 5")
-		minetest.chat_send_player(name, "Builders Day - Augest 12")
+		minetest.chat_send_player(name, "Builders Day - August 12")
 		minetest.chat_send_player(name, "Harvest Day - October 8")
 		minetest.chat_send_player(name, "New Years Eve - December 14")
 	end

--- a/leaves.lua
+++ b/leaves.lua
@@ -590,7 +590,7 @@ minetest.register_lbm({
 
       end
 
--- Augest
+-- August
       if month == 8 then
 
          -- Default Leaves

--- a/months.lua
+++ b/months.lua
@@ -41,7 +41,7 @@ local mon = {
 	{5,  "May",      t3, t3, 1},
 	{6,  "June",     t3, t3, 1.1},
 	{7,  "July",     t1, t5, 1.2},
-	{8,  "Augest",   t1, t5, 1.5},
+	{8,  "August",   t1, t5, 1.5},
 	{9,  "September",t3, t3, 1},
 	{10, "October",  t3, t3, 1},
 	{11, "November", t4, t2, .9},


### PR DESCRIPTION
August was falsely spelled "Augest" in some places. Fixed that with a search-and-replace :)

For reference: https://en.oxforddictionaries.com/definition/august